### PR TITLE
feat(storage): allow office document uploads

### DIFF
--- a/app/api/storage/create-bucket/route.ts
+++ b/app/api/storage/create-bucket/route.ts
@@ -25,7 +25,19 @@ export async function POST() {
     const { data, error } = await supabaseAdmin.storage.createBucket("content", {
       public: true,
       fileSizeLimit: 52428800, // 50MB
-      allowedMimeTypes: ["video/*", "audio/*", "application/pdf", "image/*", "text/*"],
+      allowedMimeTypes: [
+        "video/*",
+        "audio/*",
+        "application/pdf",
+        "application/msword",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "application/vnd.ms-powerpoint",
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        "application/vnd.ms-excel",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "image/*",
+        "text/*",
+      ],
     })
 
     if (error) {

--- a/lib/setup/create-storage-bucket.sql
+++ b/lib/setup/create-storage-bucket.sql
@@ -5,7 +5,19 @@ VALUES (
   'content',
   true,
   52428800, -- 50MB limit
-  ARRAY['video/*', 'audio/*', 'application/pdf', 'image/*', 'text/*']
+  ARRAY[
+    'video/*',
+    'audio/*',
+    'application/pdf',
+    'application/msword',
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    'application/vnd.ms-powerpoint',
+    'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+    'application/vnd.ms-excel',
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    'image/*',
+    'text/*'
+  ]
 )
 ON CONFLICT (id) DO NOTHING;
 

--- a/lib/setup/database-actions.ts
+++ b/lib/setup/database-actions.ts
@@ -219,8 +219,20 @@ export async function createStorageBucket() {
     // Créer le bucket
     const { data, error } = await supabaseAdmin.storage.createBucket("content", {
       public: true,
-      fileSizeLimit: 52428800, // 50MB
-      allowedMimeTypes: ["video/*", "audio/*", "application/pdf", "image/*", "text/*"],
+      fileSizeLimit: 52428800, // 50MB,
+      allowedMimeTypes: [
+        "video/*",
+        "audio/*",
+        "application/pdf",
+        "application/msword",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "application/vnd.ms-powerpoint",
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        "application/vnd.ms-excel",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "image/*",
+        "text/*",
+      ],
     })
 
     if (error) {

--- a/lib/upload/actions.ts
+++ b/lib/upload/actions.ts
@@ -105,8 +105,20 @@ export async function uploadContent(formData: FormData): Promise<UploadResult> {
         adminClient = createAdminClient()
         const { error: createError } = await adminClient.storage.createBucket("content", {
           public: true,
-          fileSizeLimit: 52428800, // 50MB
-          allowedMimeTypes: ["video/*", "audio/*", "application/pdf", "image/*", "text/*"],
+          fileSizeLimit: 52428800, // 50MB,
+          allowedMimeTypes: [
+            "video/*",
+            "audio/*",
+            "application/pdf",
+            "application/msword",
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "application/vnd.ms-powerpoint",
+            "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+            "application/vnd.ms-excel",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            "image/*",
+            "text/*",
+          ],
         })
 
         if (createError && !createError.message.includes("already exists")) {

--- a/supabase/migrations/00000000000000_initial_schema.sql
+++ b/supabase/migrations/00000000000000_initial_schema.sql
@@ -11,7 +11,19 @@ VALUES (
   'content',
   false,
   104857600, -- 100MB
-  ARRAY['video/mp4', 'video/webm', 'audio/mpeg', 'audio/wav', 'application/pdf', 'application/msword', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document']
+  ARRAY[
+    'video/*',
+    'audio/*',
+    'application/pdf',
+    'application/msword',
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    'application/vnd.ms-powerpoint',
+    'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+    'application/vnd.ms-excel',
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    'image/*',
+    'text/*'
+  ]
 );
 
 INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)


### PR DESCRIPTION
## Summary
- broaden storage bucket configuration to accept office document formats
- mirror expanded MIME types in upload routines and migrations

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_6890aa4a3bd88332ae4ef0957bf90453