### PR TITLE
Fix cache tag storage for revalidation

### DIFF
--- a/lib/cache-handler.js
+++ b/lib/cache-handler.js
@@ -24,6 +24,7 @@ class CustomCacheHandler {
     return {
       value: item.value,
       lastModified: item.lastModified,
+      tags: item.tags,
     }
   }
 
@@ -35,11 +36,13 @@ class CustomCacheHandler {
 
     const ttl = ctx?.revalidate ? ctx.revalidate * 1000 : this.defaultTTL
     const expires = Date.now() + ttl
+    const tags = Array.isArray(ctx?.tags) ? ctx.tags : []
 
     this.cache.set(key, {
       value: data,
       lastModified: Date.now(),
       expires,
+      tags,
     })
   }
 


### PR DESCRIPTION
## Summary
- ensure in-memory cache keeps track of tags so `revalidateTag` works

## Testing
- `pnpm lint` (fails: requires interactive ESLint config)
- `node - <<'NODE'` ... (verify `revalidateTag` removes tagged entry)


------
https://chatgpt.com/codex/tasks/task_e_6890642637888332ac6d5b986a464330