### PR TITLE
Synchronize auth state with login helper

### DIFF
--- a/components/auth/login-modal.tsx
+++ b/components/auth/login-modal.tsx
@@ -6,6 +6,7 @@ import { useState } from "react"
 import { useRouter } from "next/navigation"
 import Image from "next/image"
 import { createClient } from "@/lib/supabase/client"
+import { login } from "@/lib/auth"
 import {
   Dialog,
   DialogContent,
@@ -74,18 +75,14 @@ export function LoginModal({ isOpen, onClose }: LoginModalProps) {
         throw new Error("Accès non autorisé. Seuls les administrateurs peuvent se connecter.")
       }
 
-      // Store user info in localStorage for session management
-      localStorage.setItem(
-        "wakademy_admin",
-        JSON.stringify({
-          email: authData.user.email,
-          role: profile.role,
-          id: authData.user.id,
-          firstName: profile.first_name,
-          lastName: profile.last_name,
-          isAuthenticated: true,
-        }),
-      )
+      // Store user info and sync authentication state
+      login({
+        email: authData.user.email,
+        role: profile.role,
+        id: authData.user.id,
+        firstName: profile.first_name,
+        lastName: profile.last_name,
+      })
 
       // Close modal and redirect to dashboard
       onClose()

--- a/components/setup/setup-admin-form.tsx
+++ b/components/setup/setup-admin-form.tsx
@@ -4,13 +4,13 @@ import type React from "react"
 
 import { useState } from "react"
 import { useRouter } from "next/navigation"
-import { createClient } from "@/lib/supabase/client"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Loader2, Info, CheckCircle } from "lucide-react"
 import { createAdminUser } from "@/lib/setup/database-actions"
+import { login } from "@/lib/auth"
 
 interface SetupAdminFormProps {
   adminExists?: boolean
@@ -47,18 +47,14 @@ export function SetupAdminForm({ adminExists = false }: SetupAdminFormProps) {
         const userIdMatch = result.details?.match(/ID: ([a-f0-9-]+)/)
         const userId = userIdMatch ? userIdMatch[1] : null
 
-        // Stocker les informations admin dans localStorage pour la gestion de session
-        localStorage.setItem(
-          "wakademy_admin",
-          JSON.stringify({
-            email,
-            role: "admin",
-            id: userId,
-            firstName,
-            lastName,
-            isAuthenticated: true,
-          }),
-        )
+        // Stocker les informations admin et synchroniser l'authentification
+        login({
+          email,
+          role: "admin",
+          id: userId,
+          firstName,
+          lastName,
+        })
 
         setStep("success")
         setSuccess(true)

--- a/components/upload/test-user-creator.tsx
+++ b/components/upload/test-user-creator.tsx
@@ -4,7 +4,7 @@ import { useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { AlertCircle } from "lucide-react"
-import { isAuthenticated, getUser } from "@/lib/auth"
+import { isAuthenticated, getUser, login } from "@/lib/auth"
 
 export default function TestUserCreator() {
   const [isCreating, setIsCreating] = useState(false)
@@ -19,16 +19,15 @@ export default function TestUserCreator() {
     setIsCreating(true)
 
     try {
-      // Créer un utilisateur de test dans localStorage
+      // Créer un utilisateur de test et synchroniser l'état d'authentification
       const testUser = {
         id: "test-user-" + Date.now(),
         email: "test@example.com",
         name: "Utilisateur Test",
-        isAuthenticated: true,
         role: "admin",
       }
 
-      localStorage.setItem("wakademy_admin", JSON.stringify(testUser))
+      login(testUser)
 
       // Recharger la page pour appliquer les changements
       window.location.reload()


### PR DESCRIPTION
## Summary
- Use shared login helper in login modal to sync localStorage and cookies
- Apply login helper after setup to ensure admin session
- Leverage login helper for dev test user creation

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test-login` *(fails: Fichier .env non trouvé)*

------
https://chatgpt.com/codex/tasks/task_e_6890b961d79c83329bb91ecddd3aa937