### PR TITLE
feat: support multi-tenant organizations

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import { ThemeProvider } from "@/components/theme-provider"
+import { OrganizationProvider } from "@/lib/providers/organization-provider"
 import "./globals.css"
 import { headers } from "next/headers"
 
@@ -106,10 +107,12 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       </head>
       <body className="min-h-screen bg-background font-sans antialiased">
         <ThemeProvider attribute="class" defaultTheme="light" enableSystem={false} storageKey="wakademy-theme">
-          <div className="relative flex min-h-screen flex-col">
-            {/* Nous ne réservons plus d'espace ici car c'est géré dans les layouts enfants */}
-            {children}
-          </div>
+          <OrganizationProvider>
+            <div className="relative flex min-h-screen flex-col">
+              {/* Nous ne réservons plus d'espace ici car c'est géré dans les layouts enfants */}
+              {children}
+            </div>
+          </OrganizationProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/components/layout/navbar.tsx
+++ b/components/layout/navbar.tsx
@@ -26,6 +26,7 @@ import {
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { ThemeToggle } from "@/components/theme-toggle"
+import { OrganizationSwitcher } from "@/components/organization-switcher"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -123,6 +124,7 @@ function NavbarComponent() {
               Wakademy
             </span>
           </Link>
+          <OrganizationSwitcher />
         </div>
 
         {/* Search Bar - Desktop */}

--- a/components/organization-switcher.tsx
+++ b/components/organization-switcher.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import { useOrganization } from "@/lib/providers/organization-provider"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+
+export function OrganizationSwitcher() {
+  const { organizations, currentOrganization, setCurrentOrganization } = useOrganization()
+
+  if (organizations.length <= 1) return null
+
+  return (
+    <Select
+      value={currentOrganization?.id}
+      onValueChange={(id) => {
+        const org = organizations.find((o) => o.id === id) || null
+        setCurrentOrganization(org)
+      }}
+    >
+      <SelectTrigger className="w-[180px]">
+        <SelectValue placeholder="Organisation" />
+      </SelectTrigger>
+      <SelectContent>
+        {organizations.map((org) => (
+          <SelectItem key={org.id} value={org.id}>
+            {org.name}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}
+

--- a/components/settings/organization-settings.tsx
+++ b/components/settings/organization-settings.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -10,15 +10,23 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Badge } from "@/components/ui/badge"
 import { Save, Upload, Trash2, Plus, AlertTriangle } from "lucide-react"
 import { useToast } from "@/hooks/use-toast"
+import { useOrganization } from "@/lib/providers/organization-provider"
 
 export function OrganizationSettings() {
   const { toast } = useToast()
+  const { currentOrganization } = useOrganization()
   const [organization, setOrganization] = useState({
-    name: "Wakademy Corp",
+    name: currentOrganization?.name || "",
     type: "enterprise",
     description: "Plateforme de formation et de partage de connaissances pour les entreprises modernes.",
     website: "https://wakademy.com",
   })
+
+  useEffect(() => {
+    if (currentOrganization) {
+      setOrganization((prev) => ({ ...prev, name: currentOrganization.name }))
+    }
+  }, [currentOrganization])
 
   const [groups, setGroups] = useState([
     { id: 1, name: "Direction", members: 5, color: "blue" },

--- a/lib/providers/organization-provider.tsx
+++ b/lib/providers/organization-provider.tsx
@@ -1,0 +1,61 @@
+"use client"
+
+import { createContext, useContext, useEffect, useState } from "react"
+import { createClient } from "@/lib/supabase/client"
+
+interface Organization {
+  id: string
+  name: string
+}
+
+interface OrganizationContextValue {
+  organizations: Organization[]
+  currentOrganization: Organization | null
+  setCurrentOrganization: (org: Organization | null) => void
+}
+
+const OrganizationContext = createContext<OrganizationContextValue>({
+  organizations: [],
+  currentOrganization: null,
+  setCurrentOrganization: () => {},
+})
+
+export function OrganizationProvider({ children }: { children: React.ReactNode }) {
+  const [organizations, setOrganizations] = useState<Organization[]>([])
+  const [currentOrganization, setCurrentOrganization] = useState<Organization | null>(null)
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const supabase = createClient()
+        const {
+          data: { user },
+        } = await supabase.auth.getUser()
+        if (!user) return
+        const { data, error } = await supabase
+          .from("organization_members")
+          .select("organizations(id,name)")
+          .eq("user_id", user.id)
+        if (!error && data) {
+          const orgs = data.map((item: any) => item.organizations as Organization)
+          setOrganizations(orgs)
+          setCurrentOrganization(orgs[0] || null)
+        }
+      } catch (err) {
+        console.error("Failed to load organizations", err)
+      }
+    }
+    load()
+  }, [])
+
+  return (
+    <OrganizationContext.Provider value={{ organizations, currentOrganization, setCurrentOrganization }}>
+      {children}
+    </OrganizationContext.Provider>
+  )
+}
+
+export function useOrganization() {
+  return useContext(OrganizationContext)
+}
+

--- a/supabase/migrations/00000000000017_organizations.sql
+++ b/supabase/migrations/00000000000017_organizations.sql
@@ -1,0 +1,39 @@
+-- Table des organisations
+CREATE TABLE IF NOT EXISTS public.organizations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name TEXT NOT NULL,
+  owner_id UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Table des membres des organisations
+CREATE TABLE IF NOT EXISTS public.organization_members (
+  organization_id UUID REFERENCES public.organizations(id) ON DELETE CASCADE,
+  user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE,
+  role TEXT DEFAULT 'member' CHECK (role IN ('member', 'admin')),
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  PRIMARY KEY (organization_id, user_id)
+);
+
+-- Activer la RLS
+ALTER TABLE public.organizations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.organization_members ENABLE ROW LEVEL SECURITY;
+
+-- Politique RLS : un utilisateur voit les organisations dont il est membre
+CREATE POLICY "Les membres peuvent voir leurs organisations" ON public.organizations
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1 FROM public.organization_members m
+      WHERE m.organization_id = id AND m.user_id = auth.uid()
+    )
+  );
+
+-- Politique RLS : un utilisateur voit ses appartenances
+CREATE POLICY "Les utilisateurs peuvent voir leurs appartenances" ON public.organization_members
+  FOR SELECT USING (user_id = auth.uid());
+
+-- Trigger de mise à jour de updated_at
+CREATE TRIGGER on_organizations_updated
+  BEFORE UPDATE ON public.organizations
+  FOR EACH ROW EXECUTE FUNCTION public.handle_updated_at();


### PR DESCRIPTION
## Summary
- add organization provider and switcher to handle multi-tenant context
- expose current organization in settings and navbar
- define organizations and membership tables in Supabase migration

## Testing
- `pnpm lint` *(fails: many react/no-unescaped-entities and other pre-existing errors)*
- `pnpm migrate` *(fails: missing NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_6890c05ec1a083329d16b445e8b8275c